### PR TITLE
fix(archiva): add proxy host to tls ingress config

### DIFF
--- a/xetusoss-archiva/templates/ingress.yaml
+++ b/xetusoss-archiva/templates/ingress.yaml
@@ -24,5 +24,7 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - secretName: {{ .Values.ingress.tls.secretName }}
+      hosts:
+        - {{ .Values.proxy.hostname }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR adds the configured proxy hostname as an ingress' tls:hosts entry for the archiva Helm chart.

Fixes #1 

#### References
* [API documentation for IngressTLS](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#ingresstls-v1beta1-extensions)