### PR TITLE
Make chart compatible with Kubernetes v1.17.0

### DIFF
--- a/xetusoss-archiva/templates/deployment.yaml
+++ b/xetusoss-archiva/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "xetusoss-archiva.fullname" . }}
@@ -8,6 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "xetusoss-archiva.name" . }}
+      release: {{ .Release.Name }}
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
The old deployment used apiVersion: extensions/v1 which is now deprecated on Kubernetes v1.17.0. I rearranged the deployment config to be compatible with the latest version.